### PR TITLE
added fix for building non-mpi version -D_PM_WITHOUT_MPI_

### DIFF
--- a/configure
+++ b/configure
@@ -2930,8 +2930,8 @@ esac
 #
 
 if test x"$enable_mpi" = x"none" ; then
-  CXXFLAGS=-D_PM_WITHOUT_MPI_
-  CFLAGS=-D_PM_WITHOUT_MPI_
+  CXXFLAGS="$CXXFLAGS -D_PM_WITHOUT_MPI_"
+  CFLAGS="$CFLAGS -D_PM_WITHOUT_MPI_"
 else
 
 # openmpi

--- a/include/mpi_stubs.h
+++ b/include/mpi_stubs.h
@@ -62,6 +62,16 @@ namespace pm_lib {
     return 0;
   }
 
+  inline int MPI_Barrier(MPI_Comm comm)
+  {
+    return 0;
+  }
+  
+  inline int MPI_Finalize(void)
+  {
+    return 0;
+  }
+  
 }
 
 #endif /* _PM_MPI_STUBS_H_ */

--- a/src/PerfCpuType.cpp
+++ b/src/PerfCpuType.cpp
@@ -16,7 +16,11 @@
 
 // if USE_PAPI is defined, compile this file with openmp option 
 
+#ifdef _PM_WITHOUT_MPI_
+#include "mpi_stubs.h"
+#else
 #include <mpi.h>
+#endif
 #include <cmath>
 #include "PerfWatch.h"
 


### PR DESCRIPTION
Tested on vsh as:
./configure CXX=icpc CC=icc FC=ifort  CFLAGS="-std=c99 -openmp" CXXFLAGS="-openmp -DUSE_PAPI" \
--with-papi=yes  --with-example=yes  -prefix=${INSTALLED_DIR}
